### PR TITLE
More & Better Previews

### DIFF
--- a/webapps-starters/react/flowbite/src/views/browse.tsx
+++ b/webapps-starters/react/flowbite/src/views/browse.tsx
@@ -244,7 +244,9 @@ export default function Browse() {
 					        <h2 className="text-xs opacity-30 font-light">{component.versions} version(s)</h2>
 					        <div className="my-2 bg-white dark:bg-[#222] dark:text-white p-4 text-sm max-h-52 max-w-32 overflow-hidden">
 					          {component && component.component !== 'fail' ? (
-					            <component.component />
+					            <div style={{zoom: '30%'}}>
+												<component.component  />
+											</div>
 					          ) : component.component === 'fail' ? (
 					            <p className="text-xs">could not import</p>
 					          ) : (

--- a/webapps-starters/react/flowbite/src/views/view.tsx
+++ b/webapps-starters/react/flowbite/src/views/view.tsx
@@ -361,15 +361,29 @@ function App() {
 											event.preventDefault() ;
 				              setCurrentComponentIndex(i);
 				            }}
-				            className="m-1 p-2 hover:mx-2 duration-200 bg-white dark:bg-[#070707] dark:text-[#ccc] text-xs break-words"
+				            className={`m-2 p-2 hover:mx-3  ${currentComponentIndex === i ? 'mx-3' : ''} duration-200 bg-white dark:bg-[#070707] dark:text-[#ccc] text-xs break-words rounded-lg`}
 				          >
 				            {currentComponentIndex === i ? (
 				              c.description
 				            ) : (
-				              c.description.length > 100 ? `${c.description.slice(0, 97)} ...` : c.description
+				              c.description.length > 23 ? `${c.description.slice(0, 20)} ...` : c.description
 				            )}
 				            <br />
+										{
+											loadedComponents &&
+											i != null &&
+											i >= 0 &&
+											loadedComponents[i] &&
+												<div style={{zoom: '15%', pointerEvents: 'none'}}>
+													{loadedComponents.slice(i,i+1).map((item, index) => (
+														<div key={index} >
+															{ index === 0 ? <item.component /> : ''}
+														</div>
+													))}
+												</div>
+											}
 				            <span className="text-xs opacity-50">{c.version}</span>
+
 				          </a>
 				        ))}
 				      </div>

--- a/webapps-starters/react/nextui/src/views/browse.tsx
+++ b/webapps-starters/react/nextui/src/views/browse.tsx
@@ -244,7 +244,9 @@ export default function Browse() {
 					        <h2 className="text-xs opacity-30 font-light">{component.versions} version(s)</h2>
 					        <div className="my-2 bg-white dark:bg-[#222] dark:text-white p-4 text-sm max-h-52 max-w-32 overflow-hidden">
 					          {component && component.component !== 'fail' ? (
-					            <component.component />
+					            <div style={{zoom: '30%'}}>
+												<component.component  />
+											</div>
 					          ) : component.component === 'fail' ? (
 					            <p className="text-xs">could not import</p>
 					          ) : (

--- a/webapps-starters/react/nextui/src/views/view.tsx
+++ b/webapps-starters/react/nextui/src/views/view.tsx
@@ -361,15 +361,29 @@ function App() {
 											event.preventDefault() ;
 				              setCurrentComponentIndex(i);
 				            }}
-				            className="m-1 p-2 hover:mx-2 duration-200 bg-white dark:bg-[#070707] dark:text-[#ccc] text-xs break-words"
+				            className={`m-2 p-2 hover:mx-3  ${currentComponentIndex === i ? 'mx-3' : ''} duration-200 bg-white dark:bg-[#070707] dark:text-[#ccc] text-xs break-words rounded-lg`}
 				          >
 				            {currentComponentIndex === i ? (
 				              c.description
 				            ) : (
-				              c.description.length > 100 ? `${c.description.slice(0, 97)} ...` : c.description
+				              c.description.length > 23 ? `${c.description.slice(0, 20)} ...` : c.description
 				            )}
 				            <br />
+										{
+											loadedComponents &&
+											i != null &&
+											i >= 0 &&
+											loadedComponents[i] &&
+												<div style={{zoom: '15%', pointerEvents: 'none'}}>
+													{loadedComponents.slice(i,i+1).map((item, index) => (
+														<div key={index} >
+															{ index === 0 ? <item.component /> : ''}
+														</div>
+													))}
+												</div>
+											}
 				            <span className="text-xs opacity-50">{c.version}</span>
+
 				          </a>
 				        ))}
 				      </div>

--- a/webapps-starters/react/shadcn/src/views/browse.tsx
+++ b/webapps-starters/react/shadcn/src/views/browse.tsx
@@ -244,7 +244,9 @@ export default function Browse() {
 					        <h2 className="text-xs opacity-30 font-light">{component.versions} version(s)</h2>
 					        <div className="my-2 bg-white dark:bg-[#222] dark:text-white p-4 text-sm max-h-52 max-w-32 overflow-hidden">
 					          {component && component.component !== 'fail' ? (
-					            <component.component />
+					            <div style={{zoom: '30%'}}>
+												<component.component  />
+											</div>
 					          ) : component.component === 'fail' ? (
 					            <p className="text-xs">could not import</p>
 					          ) : (

--- a/webapps-starters/react/shadcn/src/views/view.tsx
+++ b/webapps-starters/react/shadcn/src/views/view.tsx
@@ -361,15 +361,29 @@ function App() {
 											event.preventDefault() ;
 				              setCurrentComponentIndex(i);
 				            }}
-				            className="m-1 p-2 hover:mx-2 duration-200 bg-white dark:bg-[#070707] dark:text-[#ccc] text-xs break-words"
+				            className={`m-2 p-2 hover:mx-3  ${currentComponentIndex === i ? 'mx-3' : ''} duration-200 bg-white dark:bg-[#070707] dark:text-[#ccc] text-xs break-words rounded-lg`}
 				          >
 				            {currentComponentIndex === i ? (
 				              c.description
 				            ) : (
-				              c.description.length > 100 ? `${c.description.slice(0, 97)} ...` : c.description
+				              c.description.length > 23 ? `${c.description.slice(0, 20)} ...` : c.description
 				            )}
 				            <br />
+										{
+											loadedComponents &&
+											i != null &&
+											i >= 0 &&
+											loadedComponents[i] &&
+												<div style={{zoom: '15%', pointerEvents: 'none'}}>
+													{loadedComponents.slice(i,i+1).map((item, index) => (
+														<div key={index} >
+															{ index === 0 ? <item.component /> : ''}
+														</div>
+													))}
+												</div>
+											}
 				            <span className="text-xs opacity-50">{c.version}</span>
+
 				          </a>
 				        ))}
 				      </div>

--- a/webapps-starters/svelte/flowbite/src/routes/+layout.svelte
+++ b/webapps-starters/svelte/flowbite/src/routes/+layout.svelte
@@ -269,8 +269,10 @@
 						<div class="my-2 bg-white dark:bg-[#222] dark:text-white p-4 text-sm
 												max-h-52 max-w-32 overflow-hidden">
 							{#if LoadedComponents[idx] && LoadedComponents[idx] != 'fail'}
-								<svelte:component this={LoadedComponents[idx]} >
-								</svelte:component>
+								<div style={{zoom: '30%'}}>
+									<svelte:component this={LoadedComponents[idx]} >
+									</svelte:component>
+								</div>
 							{:else if LoadedComponents[idx] && LoadedComponents[idx] === 'fail'}
 							  <p class="text-xs">could not import</p>
 							{:else}

--- a/webapps-starters/svelte/flowbite/src/routes/view/[name]/+layout.svelte
+++ b/webapps-starters/svelte/flowbite/src/routes/view/[name]/+layout.svelte
@@ -304,9 +304,15 @@
               {#if currentComponentIndex == i}
 	             {c.description}
               {:else}
-                {c.description.length > 100 ? `${c.description.slice(0,97)} ...` : c.description}
+                {c.description.length > 23 ? `${c.description.slice(0,20)} ...` : c.description}
               {/if}
 	            <br/>
+              {#if LoadedComponents && i != null && i >= 0 && LoadedComponents[i]}
+                <div style={{zoom: '15%', pointerEvents: 'none'}}>
+                  <svelte:component this={LoadedComponents[i]} >
+                  </svelte:component>
+                </div>
+              {/if}
 	            <span class="text-xs opacity-50">{c.version}</span>
 	          </a>
 	        {/each}


### PR DESCRIPTION
- Fixed the zoomed in previews on the browse page
- Added inline previews for each iteration of a component
- Works in both React and svetle

![image](https://github.com/raidendotai/openv0/assets/109481728/6bf2485c-6dd5-4b8a-a173-be2e5a32cdad)
![image](https://github.com/raidendotai/openv0/assets/109481728/079a150a-b3b3-42fb-88d3-bc48751e6044)
![image](https://github.com/raidendotai/openv0/assets/109481728/a50922ef-8dfb-4634-8312-6b7d99f06fef)
![image](https://github.com/raidendotai/openv0/assets/109481728/dd588bac-1b7d-4ab9-80fa-0964e23a6809)
