### PR TITLE
feat: custom api baseURL

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -5,4 +5,5 @@ OPENV0__API = "https://api.openv0.com"
 API__GENERATE_ATTEMPTS = 1
 
 WEBAPP_ROOT = "../webapp"
+# OPENAI_API_BASEURL = "https://api.openai.com/v1"
 OPENAI_API_KEY = "YOUR_OPENAI_KEY"

--- a/server/modules/multipass/passes/build-component-generation-context/rag_icons.js
+++ b/server/modules/multipass/passes/build-component-generation-context/rag_icons.js
@@ -5,6 +5,7 @@ const { LocalIndex } = require(`vectra`);
 const { OpenAI } = require("openai");
 require("dotenv").config();
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 

--- a/server/modules/multipass/passes/design-component-iteration-from-description/index.js
+++ b/server/modules/multipass/passes/design-component-iteration-from-description/index.js
@@ -8,6 +8,7 @@ const { OpenAI } = require("openai");
 require("dotenv").config();
 const path = require("path");
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 

--- a/server/modules/multipass/passes/design-component-iteration-from-json/index.js
+++ b/server/modules/multipass/passes/design-component-iteration-from-json/index.js
@@ -8,6 +8,7 @@ const { OpenAI } = require("openai");
 require("dotenv").config();
 const path = require("path");
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 

--- a/server/modules/multipass/passes/design-component-new-from-description/index.js
+++ b/server/modules/multipass/passes/design-component-new-from-description/index.js
@@ -8,6 +8,7 @@ const { OpenAI } = require("openai");
 require("dotenv").config();
 const path = require("path");
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 

--- a/server/modules/multipass/passes/design-component-new-from-json/index.js
+++ b/server/modules/multipass/passes/design-component-new-from-json/index.js
@@ -8,6 +8,7 @@ const { OpenAI } = require("openai");
 require("dotenv").config();
 const path = require("path");
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 

--- a/server/modules/multipass/passes/generate-component-iteration/index.js
+++ b/server/modules/multipass/passes/generate-component-iteration/index.js
@@ -4,6 +4,7 @@ const tiktoken = require("@dqbd/tiktoken");
 const tiktokenEncoder = tiktoken.get_encoding("cl100k_base");
 require("dotenv").config();
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 

--- a/server/modules/multipass/passes/generate-component-new/index.js
+++ b/server/modules/multipass/passes/generate-component-new/index.js
@@ -4,6 +4,7 @@ const tiktoken = require("@dqbd/tiktoken");
 const tiktokenEncoder = tiktoken.get_encoding("cl100k_base");
 require("dotenv").config();
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 

--- a/server/modules/multipass/passes/validate-fix-generated-component/index.js
+++ b/server/modules/multipass/passes/validate-fix-generated-component/index.js
@@ -8,6 +8,7 @@ const tiktoken = require("@dqbd/tiktoken");
 const tiktokenEncoder = tiktoken.get_encoding("cl100k_base");
 require("dotenv").config();
 const openai = new OpenAI({
+  baseURL: process.env.OPENAI_API_BASEURL,
   apiKey: process.env.OPENAI_API_KEY,
 });
 


### PR DESCRIPTION
support custom openai api prefix:
pass `process.env. OPENAI_API_BASEURL` to `OpenAIOpt.baseURL`
